### PR TITLE
Remove state in FPO.setProp

### DIFF
--- a/lib/fpo.src.js
+++ b/lib/fpo.src.js
@@ -372,9 +372,7 @@
 	}
 
 	function setProp({ prop = "", o: obj = {}, v } = {}) {
-		obj = Object.assign( {}, obj );
-		obj[prop] = v;
-		return obj;
+		return Object.assign( {}, obj, { [prop]: v } );
 	}
 
 	function filterIn({ fn: predicateFn, arr = [] } = {}) {


### PR DESCRIPTION
- By removing assignments from the function body, we have
reduced the cognitive load just a tiny bit.

***

- First of all, forgive me if contributions are not welcome to this repo (yet). 
- Second of all, I know this commit neither adds a feature or fixes a bug, but I think it has value anyway. It was merely a small improvement that caught my eye. In my own work, I do everything I can to limit assignments.
- Finally, I'm a fan of you and your books. Keep up the good work.